### PR TITLE
Prevent notice in ArrayPersistor 

### DIFF
--- a/src/MaBandit/Persistence/ArrayPersistor.php
+++ b/src/MaBandit/Persistence/ArrayPersistor.php
@@ -25,7 +25,7 @@ class ArrayPersistor implements Persistor
 
   public function loadLeversForExperiment(\MaBandit\Persistence\PersistedLever $lever)
   {
-	  $the_lever = $lever->getExperiment();
-	  return (isset($this->_levers[$the_lever])) ? $this->_levers[$the_lever] : array();
+    $the_lever = $lever->getExperiment();
+    return (isset($this->_levers[$the_lever])) ? $this->_levers[$the_lever] : array();
   }
 }

--- a/src/MaBandit/Persistence/ArrayPersistor.php
+++ b/src/MaBandit/Persistence/ArrayPersistor.php
@@ -25,6 +25,11 @@ class ArrayPersistor implements Persistor
 
   public function loadLeversForExperiment(\MaBandit\Persistence\PersistedLever $lever)
   {
-    return $this->_levers[$lever->getExperiment()] ?: array();
+	  $the_lever = $lever->getExperiment();
+	  if( isset( $this->_levers[ $the_lever ] )  ) {
+		  return $this->_levers[ $the_lever ];
+	  }else{
+		  return array();
+	  }
   }
 }

--- a/src/MaBandit/Persistence/ArrayPersistor.php
+++ b/src/MaBandit/Persistence/ArrayPersistor.php
@@ -26,10 +26,6 @@ class ArrayPersistor implements Persistor
   public function loadLeversForExperiment(\MaBandit\Persistence\PersistedLever $lever)
   {
 	  $the_lever = $lever->getExperiment();
-	  if( isset( $this->_levers[ $the_lever ] )  ) {
-		  return $this->_levers[ $the_lever ];
-	  }else{
-		  return array();
-	  }
+	  return (isset($this->_levers[$the_lever])) ? $this->_levers[$the_lever] : array();
   }
 }


### PR DESCRIPTION
Testing with PHP 5.5, when the `_levers` property didn't contain the lever being requested, I was receiving a PHP notice.
